### PR TITLE
Selections Improvements

### DIFF
--- a/lib/commands/editor.js
+++ b/lib/commands/editor.js
@@ -14,7 +14,10 @@ export default {
   /**
    * @other change mode to insert
    */
-  i: withoutGoto((_, { instance }) => instance.changeModeToInsert()),
+  i: withoutGoto((editor, { instance }) => {
+    editor.getSelections().forEach(selection => selection.clear())
+    instance.changeModeToInsert()
+  }),
   /**
    * @changes undo last change
    * @shift redo last change

--- a/lib/commands/selection.js
+++ b/lib/commands/selection.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import matchingCharCommand from './matchingCharCommand'
-import { getMovementCommand, getSelectionCommand } from './utils/index'
+import { getMovementCommand, getSelectionCommand, isCursorAtBeginningOfSelection } from './utils/index'
 import { withCount, withGoto, withoutGoto } from './utils/decorators'
 
 // selection commands will be triggered for each selection
@@ -114,5 +114,13 @@ export default {
   /**
    * @selections reduce selections to their cursor
    */
-  ';': selection => selection.clear(),
+  ';': selection => {
+    // TODO: this is a bit hacky. We should really _set_ the selection to what we
+    // want. (This approach also has the side effect of constantly swapping the
+    // cursor if the ';' button is hit repeatedly)
+    const cursorAtBeginningOfSelection = isCursorAtBeginningOfSelection(selection.cursor)
+    selection.clear()
+    if (cursorAtBeginningOfSelection) selection.selectRight()
+    else selection.selectLeft()
+  },
 }

--- a/lib/commands/utils/index.js
+++ b/lib/commands/utils/index.js
@@ -2,6 +2,12 @@
 
 import { last, init } from 'ramda'
 
+export const isCursorAtBeginningOfSelection = cursor => {
+  const selectionStart = cursor.selection.getBufferRange().start
+  const cursorPosition = cursor.getBufferPosition()
+  return selectionStart.row === cursorPosition.row && selectionStart.column === cursorPosition.column
+}
+
 export const getMovementCommand = type => (
   { cursor },
   { withShift, withAlt, isGoToActive }
@@ -15,7 +21,11 @@ export const getMovementCommand = type => (
       cursor.selection.addSelectionAbove()
     }
   } else {
+    if (!isCursorAtBeginningOfSelection(cursor)) {
+      cursor.moveLeft()
+    }
     cursor[`move${type}`]()
+    cursor.selection.selectRight()
   }
 }
 

--- a/lib/kak-mode.js
+++ b/lib/kak-mode.js
@@ -8,7 +8,7 @@ import { INIT_STATE, ATOM_TEXT_EDITOR, MODES } from './consts'
 import { getStatusBar, updateStatusBar } from './status-bar'
 import { getKeys } from './keys'
 import { selectToMatch } from './commands/utils/occurence'
-import { updateString } from './commands/utils/index'
+import { isCursorAtBeginningOfSelection, updateString } from './commands/utils/index'
 import editorCommands from './commands/editor'
 import selectionCommands from './commands/selection'
 import { setSearchSelection } from './commands/search'
@@ -19,6 +19,7 @@ export default {
   subscriptions: null,
 
   state: INIT_STATE,
+  decorations: {},
 
   reset () {
     this.updateState(INIT_STATE)
@@ -145,6 +146,21 @@ export default {
 
           runCommands(editorCommands)
           runCommands(selectionCommands, editor.getSelections())
+          const oldDecorations = { ...this.decorations }
+          this.decorations = {}
+          editor.getSelections().forEach(selection => {
+            // I'm doing this because I'm assuming that it's expensive to create decorations (that might be a false assumption)
+            if (oldDecorations[selection.cursor.marker.id]) {
+              this.decorations[selection.cursor.marker.id] = oldDecorations[selection.cursor.marker.id]
+            } else {
+              this.decorations[selection.cursor.marker.id] = editor.decorateMarker(selection.cursor.marker, { type: 'cursor', class: '' })
+            }
+            if (isCursorAtBeginningOfSelection(selection.cursor)) {
+              this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-beginning-of-selection' })
+            } else {
+              this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-end-of-selection' })
+            }
+          })
         }
 
         if (escapePressed && count > 0) {

--- a/lib/kak-mode.js
+++ b/lib/kak-mode.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import { CompositeDisposable } from 'atom'
+import { CompositeDisposable, Point, Range } from 'atom'
 import { mergeDeepRight, equals } from 'ramda'
 
 import config from './config'
@@ -14,12 +14,32 @@ import selectionCommands from './commands/selection'
 import { setSearchSelection } from './commands/search'
 import updateEditorClass from './updateEditorClass.js'
 
+// Mostly taken from: https://github.com/atom/atom/blob/v1.44.0/src/cursor.js#L328-L343
+function getScreenPositionToRight (editor, screenPosition) {
+  let columnCount = 1
+  let { row, column } = screenPosition
+  const maxLines = editor.getScreenLineCount()
+  let rowLength = editor.lineLengthForScreenRow(row)
+  let columnsRemainingInLine = rowLength - column
+
+  while (columnCount > columnsRemainingInLine && row < maxLines - 1) {
+    columnCount -= columnsRemainingInLine
+    columnCount-- // subtract 1 for the row move
+
+    column = 0
+    rowLength = editor.lineLengthForScreenRow(++row)
+    columnsRemainingInLine = rowLength
+  }
+
+  column = column + columnCount
+  return new Point(row, column)
+}
+
 export default {
   config,
   subscriptions: null,
 
   state: INIT_STATE,
-  decorations: {},
 
   reset () {
     this.updateState(INIT_STATE)
@@ -59,6 +79,41 @@ export default {
   },
   changeModeToNormal () {
     this.updateState({ mode: MODES.NORMAL })
+  },
+
+  onMouseDownOnTextEditor (e) {
+    if (this.state.mode !== MODES.NORMAL) return
+    e.currentTarget.focus()
+    const editor = e.currentTarget.getModel()
+    const screenPosition = e.currentTarget.component.screenPositionForMouseEvent(e)
+    editor.setSelectedScreenRange(new Range(screenPosition, getScreenPositionToRight(editor, screenPosition)))
+    this.updateCursorStyles(editor)
+    e.preventDefault()
+  },
+
+  addMouseEvents (editor) {
+    if (editor) {
+      editor.editorElement.addEventListener('mousedown', this.onMouseDownOnTextEditor.bind(this))
+    }
+  },
+
+  decorations: {},
+  updateCursorStyles (editor) {
+    const oldDecorations = { ...this.decorations }
+
+    editor.getSelections().forEach(selection => {
+    // I'm doing this because I'm assuming that it's expensive to create decorations (that might be a false assumption)
+      if (oldDecorations[selection.cursor.marker.id]) {
+        this.decorations[selection.cursor.marker.id] = oldDecorations[selection.cursor.marker.id]
+      } else {
+        this.decorations[selection.cursor.marker.id] = editor.decorateMarker(selection.cursor.marker, { type: 'cursor', class: '' })
+      }
+      if (isCursorAtBeginningOfSelection(selection.cursor)) {
+        this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-beginning-of-selection' })
+      } else {
+        this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-end-of-selection' })
+      }
+    })
   },
 
   activate (state) {
@@ -146,21 +201,7 @@ export default {
 
           runCommands(editorCommands)
           runCommands(selectionCommands, editor.getSelections())
-          const oldDecorations = { ...this.decorations }
-          this.decorations = {}
-          editor.getSelections().forEach(selection => {
-            // I'm doing this because I'm assuming that it's expensive to create decorations (that might be a false assumption)
-            if (oldDecorations[selection.cursor.marker.id]) {
-              this.decorations[selection.cursor.marker.id] = oldDecorations[selection.cursor.marker.id]
-            } else {
-              this.decorations[selection.cursor.marker.id] = editor.decorateMarker(selection.cursor.marker, { type: 'cursor', class: '' })
-            }
-            if (isCursorAtBeginningOfSelection(selection.cursor)) {
-              this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-beginning-of-selection' })
-            } else {
-              this.decorations[selection.cursor.marker.id].setProperties({ type: 'cursor', class: 'at-end-of-selection' })
-            }
-          })
+          this.updateCursorStyles(editor)
         }
 
         if (escapePressed && count > 0) {
@@ -205,6 +246,8 @@ export default {
         }, {}),
       },
     })
+
+    this.subscriptions.add(atom.workspace.observeTextEditors(this.addMouseEvents.bind(this)))
 
     // handle events while in search mode
     const editor = atom.workspace.getActiveTextEditor()

--- a/styles/kak-mode.less
+++ b/styles/kak-mode.less
@@ -45,6 +45,7 @@ atom-workspace.kak-mode-normal {
 
     &.at-end-of-selection {
         background: unset;
+        opacity: 1;
 
         &::before {
             background: @syntax-cursor-color;

--- a/styles/kak-mode.less
+++ b/styles/kak-mode.less
@@ -42,5 +42,20 @@ atom-workspace.kak-mode-normal {
     background: @syntax-cursor-color; // Setting background creates a block cursor
     border: none;
     opacity: 0.5;
+
+    &.at-end-of-selection {
+        background: unset;
+
+        &::before {
+            background: @syntax-cursor-color;
+            border: none;
+            content: "";
+            height: 100%;
+            opacity: 0.5;
+            position: absolute;
+            right: 100%;
+            width: 100%;
+        }
+    }
   }
 }


### PR DESCRIPTION
This pull request makes a number of improvements to how selections are handled. These changes are driven by the core realization that Kakoune _always_ has a selection of size 1 or large. To match that behavior these changes work to eliminate the possibility of a selection collapsing when in normal mode.

The specific changes made in this PR include:
* Clearing selections when entering insert mode, in order to match the native Atom editing experience
* Creating selection when using the alpha movement commands (rather than moving the cursor, which can cause selections to collapse)
* Retaining selections when reducing to the cursor using the `;` key
* Creating selections when clicking with the mouse 
* Updating the cursor style to more clearly indicate whether it's at the beginning or end of a selection

There are still some edge cases that this PR doesn't handle (particular with handling mouse events), but I've found these improvements to be a huge step forward so far.